### PR TITLE
The script recognizes only *.jar files in deep subdirectorys -gt 3

### DIFF
--- a/Invoke-Log4ShellScan.ps1
+++ b/Invoke-Log4ShellScan.ps1
@@ -45,7 +45,7 @@ BEGIN {
                                 
                             } # files
                             else {
-                                Get-ChildItem $Path  -force -include *.jar -ErrorAction SilentlyContinue | ForEach-Object {
+                                Get-ChildItem (Join-Path $Path "*.jar") -force -ErrorAction SilentlyContinue | ForEach-Object {
                                     if (select-string "JndiLookup.class" $_.FullName) {
                                         $_ | Select-Object -Property @{N="Computername";E={$ENV:COMPUTERNAME}}, Name, FullName
                                     }


### PR DESCRIPTION
The script recognizes only *.jar files in deep subdirectorys -gt 3


```powershell
### Create Test-Enviroment

[Hashtable]$hasNewFile = @{
  Name = 'test.jar' 
  Value = 'my Reference to JndiLookup.class' 
  Force = $true
}
[Object[]]$obaPaths = @('C:\','C:\subdirectory1','C:\subdirectory1\subdirectory2')
foreach ($strPath in $obaPaths){
  if(!(Test-Path -Path $strPath)){
    New-Item -Path $strPath -Type 'Directory'
  }
  if(!(Test-Path (Join-Path -Path $strPath -ChildPath $hasNewFile.Name))){
    New-Item -Path $strPath @hasNewFile
  }
}

### Start script

<# result expected in csv
"Computername","Name","FullName"
"Testserver","test.jar","C:\test.jar"
"Testserver","test.jar","C:\subdirectory1"
"Testserver","test.jar","C:\subdirectory1\subdirectory2"
#>

<# result original
"Computername","Name","FullName"
"Testserver","test.jar","C:\subdirectory1\subdirectory2"
#>


### Test

foreach ($strPath in $obaPaths){
  Get-ChildItem $strPath -force -include *.jar -ErrorAction SilentlyContinue | `
    Should -BeNullOrEmpty #-Because 'CmdLet does not look recurse'

  Get-ChildItem (Join-Path $strPath "*.jar") -force -ErrorAction SilentlyContinue | `
    Should -Not -BeNullOrEmpty #-Because 'CmdLet looks for all files in directory'
}




### Clean Test-Enviroment

[Object]$obaReverse = $obaPaths | Sort-Object -Descending
foreach ($strPath in $obaReverse){
  [String]$strFile = (Join-Path -Path $strPath -ChildPath $hasNewFile.Name)
  if(Test-Path $strFile){
    Remove-Item -Path $strFile -Confirm:$false
  }
  #Only Remove Empty Folders
  if(![Boolean](`
      Get-ChildItem -Recurse -Path $strPath -Depth 1 `
        -ErrorAction 'SilentlyContinue' 
  )){
    Remove-Item -Path $strPath -Confirm:$false
  }
}
```